### PR TITLE
Fix location of API download when called from external module

### DIFF
--- a/updateAPI.js
+++ b/updateAPI.js
@@ -17,7 +17,7 @@ function getAPI(host, callback) {
 			return;
 		}
 		try {
-			fs.writeFileSync('lib/api.js', body);
+			fs.writeFileSync(__dirname + '/lib/api.js', body);
 			//console.log('Successfully written api.js');
 			if(typeof callback == 'function') {
 				callback(null);


### PR DESCRIPTION
If calling getAPI from parent module (getAPI = require(node_modules/ipcortex-pabx/updateAPI)) this wrote api.js to a /lib directory relative to the parent module, not /ipcortex-pabx/lib as desired. This feature mirrors the read of api.js in index.js which uses __dirname to locate it.
